### PR TITLE
Xml clan and kingdom crash fix

### DIFF
--- a/SeparatistCrisis/ModuleData/heroes.xml
+++ b/SeparatistCrisis/ModuleData/heroes.xml
@@ -20,9 +20,11 @@
 
   <Hero id="mando_awaud_nam" is_noble="true" faction="Faction.clan_awaud" text="Is Nam Beroyas, Leader of Clan Awaud" />
   <Hero id="satine_kryze" is_noble="true" faction="Faction.house_kryze" text="Leader of the New Mandalorians, and House Kryze" />
-  <Hero id="pre_vizsla" is_noble="true" faction="Faction.clan_vizsla" text="Pre Vizsla was a human male Mandalorian warrior who led a terrorist organization, known as Death Watch, during the final years of the Galactic Republic. Formerly the governor of Concordia, Vizsla longed to restore the warrior heritage of his homeworld, the planet Mandalore, by overthrowing Duchess Satine Kryze's pacifist regime." />
-  <Hero id="bo_katan" is_noble="true" faction="Faction.clan_vizsla" text="Leader of the Nite Owls" />
-  <!--<Hero id="mando_awaud_kad" is_noble="true" faction="Faction.mando_awaud" father="Hero.mando_awaud_avin" text="Adopted by Avin Solus" />
+  <Hero id="pre_vizsla" is_noble="true" faction="Faction.house_kryze" text="Pre Vizsla was a human male Mandalorian warrior who led a terrorist organization, known as Death Watch, during the final years of the Galactic Republic. Formerly the governor of Concordia, Vizsla longed to restore the warrior heritage of his homeworld, the planet Mandalore, by overthrowing Duchess Satine Kryze's pacifist regime." />
+  <Hero id="bo_katan" is_noble="true" faction="Faction.house_kryze" text="Leader of the Nite Owls" />
+  <!--
+  <Hero id="mando_awaud_kad" is_noble="true" faction="Faction.mando_awaud" father="Hero.mando_awaud_avin" text="Adopted by Avin Solus" />
   <Hero id="mando_awaud_avin" is_noble="true" faction="Faction.mando_awaud" text="Mandalorian mercenary" />
-  <Hero id="mando_awaud_teroch" is_noble="true" faction="Faction.mando_awaud" text="Well seasoned mercenary with no interest in politics" />-->
+  <Hero id="mando_awaud_teroch" is_noble="true" faction="Faction.mando_awaud" text="Well seasoned mercenary with no interest in politics" />
+  -->
 </Heroes>

--- a/SeparatistCrisis/ModuleData/settlements.xml
+++ b/SeparatistCrisis/ModuleData/settlements.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settlements>
+  <!-- Empire = 19 towns, 52 villages, 9 castles, 2.73 villages per town, 18% castle ratio -->  
+  <Settlement id="town_mandalore" name="Mandalore" owner="Faction.house_kryze" posX="590.71" posY="597.85" culture="Culture.mandalorians" prosperity="2100" gate_posX="587.71" gate_posY="594.19">
+    <Components>
+      <Town id="town_comp_mandalore" is_castle="false" level="3" background_crop_position="0.0" background_mesh="gui_bg_town_sturgia" wait_mesh="wait_sturgia_town" gate_rotation="0.308" />
+    </Components>
+    <Locations complex_template="LocationComplexTemplate.town_complex">
+      <Location id="center" scene_name="sturgia_town_c" scene_name_1="sturgia_town_c" scene_name_2="sturgia_town_c" scene_name_3="sturgia_town_c" />
+      <Location id="arena" scene_name="arena_sturgia_a" />
+      <Location id="tavern" scene_name="sturgia_house_b_interior_tavern" />
+      <Location id="lordshall" scene_name_1="sturgia_castle_keep_a_l2_interior" scene_name_2="sturgia_castle_keep_a_l2_interior" scene_name_3="sturgia_castle_keep_a_l3_interior" />
+      <Location id="prison" scene_name="sturgia_dungeon_a" />
+      <Location id="house_1" scene_name="sturgia_town_house_d1_interior_b_house" />
+      <Location id="house_2" scene_name="sturgia_town_house_d1_interior_b_house" />
+      <Location id="house_3" scene_name="sturgia_town_house_d1_interior_b_house" />
+    </Locations>
+    <CommonAreas>
+      <Area type="Backstreet" name="{=a0MVffcN}Backstreet" />
+      <Area type="Clearing" name="{=LWHIVshb}Clearing" />
+      <Area type="Waterfront" name="{=Rr1cy5Sk}Waterfront" />
+    </CommonAreas>
+  </Settlement>
+  
+<!--
+  <Settlement id="castle_village_mandalore" name="Mandalore Village" posX="272.394" posY="152.421" culture="Culture.aserai" text="Desc">
+    <Components>
+      <Village id="castle_village_comp_mandalore" village_type="VillageType.desert_horse_ranch" hearth="305" trade_bound="Settlement.town_mandalore" bound="Settlement.town_mandalore" background_crop_position="0.214" background_mesh="menu_aserai_village_1" wait_mesh="wait_aserai_village" castle_background_mesh="gui_bg_castle_aserai" />
+    </Components>
+    <Locations complex_template="LocationComplexTemplate.village_complex">
+      <Location id="village_center" scene_name="aserai_village_i" />
+    </Locations>
+    <CommonAreas>
+      <Area type="Pasture" name="{=fOUsLdZR}Pasture" />
+      <Area type="Thicket" name="{=66Mzk0NZ}Thicket" />
+      <Area type="Bog" name="{=iXA5SttU}Bog" />
+    </CommonAreas>
+  </Settlement>
+-->
+
+  <Settlement id="town_coruscant" name="Coruscant" owner="Faction.galactic_senate" posX="577.05" posY="314.13" culture="Culture.galactic_republic" prosperity="2100" gate_posX="577.81" gate_posY="312.31">
+    <Components>
+      <Town id="town_comp_coruscant" is_castle="false" level="3" background_crop_position="0.401" background_mesh="menu_aserai_4" wait_mesh="wait_aserai_town" gate_rotation="0.408" />
+    </Components>
+    <Locations complex_template="LocationComplexTemplate.town_complex">
+      <Location id="center" scene_name="aserai_town_a" scene_name_1="aserai_town_a" scene_name_2="aserai_town_a" scene_name_3="aserai_town_a" />
+      <Location id="arena" scene_name="arena_aserai_a" />
+      <Location id="tavern" scene_name="aserai_tavern_interior" />
+      <Location id="lordshall" scene_name_1="aserai_castle_keep_a_l1_interior" scene_name_2="aserai_castle_keep_a_l2_interior" scene_name_3="aserai_castle_keep_a_l3_interior" />
+      <Location id="prison" scene_name="aserai_dungeon_a" />
+      <Location id="house_1" scene_name="arabian_house_new_a_interior_a_house" />
+      <Location id="house_2" scene_name="arabian_house_new_a_interior_a_house" />
+      <Location id="house_3" scene_name="arabian_house_new_a_interior_a_house" />
+    </Locations>
+    <CommonAreas>
+      <Area type="Backstreet" name="{=a0MVffcN}Backstreet" />
+      <Area type="Clearing" name="{=LWHIVshb}Clearing" />
+      <Area type="Waterfront" name="{=Rr1cy5Sk}Waterfront" />
+    </CommonAreas>
+  </Settlement>
+  
+  <Settlement id="town_geonosis" name="Geonosis" owner="Faction.separatistalliance" posX="802.47" posY="391.67" culture="Culture.separatistalliance" prosperity="2100" gate_posX="801.83" gate_posY="393.53">
+    <Components>
+      <Town id="town_comp_geonosis" is_castle="false" level="3" background_crop_position="0.401" background_mesh="menu_aserai_4" wait_mesh="wait_aserai_town" gate_rotation="0.408" />
+    </Components>
+    <Locations complex_template="LocationComplexTemplate.town_complex">
+      <Location id="center" scene_name="aserai_town_a" scene_name_1="aserai_town_a" scene_name_2="aserai_town_a" scene_name_3="aserai_town_a" />
+      <Location id="arena" scene_name="arena_aserai_a" />
+      <Location id="tavern" scene_name="aserai_tavern_interior" />
+      <Location id="lordshall" scene_name_1="aserai_castle_keep_a_l1_interior" scene_name_2="aserai_castle_keep_a_l2_interior" scene_name_3="aserai_castle_keep_a_l3_interior" />
+      <Location id="prison" scene_name="aserai_dungeon_a" />
+      <Location id="house_1" scene_name="arabian_house_new_a_interior_a_house" />
+      <Location id="house_2" scene_name="arabian_house_new_a_interior_a_house" />
+      <Location id="house_3" scene_name="arabian_house_new_a_interior_a_house" />
+    </Locations>
+    <CommonAreas>
+      <Area type="Backstreet" name="{=a0MVffcN}Backstreet" />
+      <Area type="Clearing" name="{=LWHIVshb}Clearing" />
+      <Area type="Waterfront" name="{=Rr1cy5Sk}Waterfront" />
+    </CommonAreas>
+  </Settlement>
+
+</Settlements>

--- a/SeparatistCrisis/ModuleData/spclans.xml
+++ b/SeparatistCrisis/ModuleData/spclans.xml
@@ -16,7 +16,7 @@
            tier="3"
            text="{=bhxVA9w7}The Galactic Republic, also known as the Grand Republic or simply as the Republic, was a democratic union comprised of various member worlds spread across light-years of space."></Faction>
 
-  <Faction id="separatist_alliance"
+  <Faction id="separatistalliance"
            owner="Hero.count_dooku"
            banner_key="11.101.75.4345.4345.764.764.1.0.0.427.1.0.415.388.695.764.0.0.270.521.1.0.293.298.822.764.0.0.324"    
            label_color="FFD2C0AA"
@@ -165,7 +165,7 @@
            super_faction="Kingdom.mandalorian_loyalists" 
            tier="3"
            text="{=bhxVA9w7}House Kryze was under the leadership of Duchess Satine Kryze during the Clone Wars, who led the New Mandalorian government."></Faction>
-
+<!--
   <Faction id="clan_vizsla"
            owner="Hero.pre_vizsla"
            banner_key="11.147.147.1536.1536.764.764.1.0.0.215.155.155.442.442.764.764.0.0.0"           
@@ -195,7 +195,7 @@
            super_faction="Kingdom.deathwatch" 
            tier="3"
            text="{=bhxVA9w7}The Nite Owls were an elite Mandalorian unit made up of warriors led by Bo-Katan Kryze. When Bo-Katan joined Death Watch, the Nite Owls sided with the group and with its leader, Pre Vizsla."></Faction>
-
+-->
   <Faction id="clan_awaud"
            owner="Hero.mando_awaud_nam"
            banner_key="11.147.147.1536.1536.764.764.1.0.0.215.155.155.442.442.764.764.0.0.0"          

--- a/SeparatistCrisis/ModuleData/spcultures.xml
+++ b/SeparatistCrisis/ModuleData/spcultures.xml
@@ -7,6 +7,7 @@
            color2="FFDE9953"
            elite_basic_troop="NPCCharacter.arf_clone"
            basic_troop="NPCCharacter.clone_cadet"
+		   basic_mercenary_troop="NPCCharacter.mercenary_1"
            melee_militia_troop="NPCCharacter.clone_cadet"
            ranged_militia_troop="NPCCharacter.clone_cadet"
            melee_elite_militia_troop="NPCCharacter.republic_clone_sergeant_troop"

--- a/SeparatistCrisis/ModuleData/spkingdoms.xml
+++ b/SeparatistCrisis/ModuleData/spkingdoms.xml
@@ -79,6 +79,7 @@
     </policies>
   </Kingdom>
 
+ <!--
 <Kingdom id="deathwatch" 
     owner="Hero.pre_vizsla" 
     banner_key="11.152.152.1536.1536.768.768.1.0.0.102.149.15.555.555.769.764.1.0.0" 
@@ -104,4 +105,5 @@
       <policy id="policy_feudal_inheritance" />
     </policies>
   </Kingdom>
+  -->
 </Kingdoms>

--- a/SeparatistCrisis/SubModule.xml
+++ b/SeparatistCrisis/SubModule.xml
@@ -132,5 +132,26 @@
 		<XmlNode>                
 			<XmlName id="WeaponDescriptions" path="weapon_descriptions"/>
 		</XmlNode>
+			  <XmlNode>                
+		<XmlName id="Kingdoms" path="spkingdoms"/>
+		<IncludedGameTypes>
+			<GameType value = "Campaign"/>
+			<GameType value = "CampaignStoryMode"/>
+		</IncludedGameTypes>
+	</XmlNode>
+		  <XmlNode>
+		  <XmlName id="Factions" path="spclans"/>
+		  <IncludedGameTypes>
+			  <GameType value = "Campaign"/>
+			  <GameType value = "CampaignStoryMode"/>
+		  </IncludedGameTypes>
+	  </XmlNode>
+	  <XmlNode>                
+		<XmlName id="Settlements" path="settlements"/>
+		<IncludedGameTypes>
+			<GameType value = "Campaign"/>
+			<GameType value = "CampaignStoryMode"/>
+		</IncludedGameTypes>
+	</XmlNode>
   </Xmls>
 </Module>


### PR DESCRIPTION
- added reference for clans and kingdoms in submodules.xml
- added missing troop reference for the republic culture
- added a settlements xml for the three ghost towns. They are assigned to republic, cis and mandalore
- deactivate deathwatch because they dont have a settlement which causes a crash since bannerlord uses settlements as spawn positions for charackters